### PR TITLE
Use link for latest version for documentation

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -169,7 +169,7 @@ The Tidy GHG Inventories dataset is a compilation of national greenhouse gas emi
 
 
 <p>
-<a target='_blank' href='https://zenodo.org/records/14637347'>The data repository and documentation is available here.</a>
+<a target='_blank' href='https://doi.org/10.5281/zenodo.14512139'>The data repository and documentation is available here.</a>
 </p>
 
 <p>


### PR DESCRIPTION
This is the link from Zenodo with

> 'You can cite all versions by using the DOI [10.5281/zenodo.14512139](https://doi.org/10.5281/zenodo.14512139). This DOI represents all versions, and will always resolve to the latest one.'

I hope the .rmd file is the right place to make a change.